### PR TITLE
Fix using group reserved keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ When we started using CosmosDB it was still called DocumentDB. At that time the 
 
 After we realized that it is unlikely for Microsoft to support oData for CosmosDb, I thought ok, we will get this package and build on top of it. I couldn't get a PR approved to the original repository because the original author is not responding therefore, I forked it. But it's proven to be more challenging that I originally thought. 
 
-It turned out that there are heaps of features missing from this code-base and IMHO it's not written in the prettiest way possible. It's also based on .Net 4.6.2 which means no support for .Net Code 2 or .Net Standard 2.
+It turned out that there are heaps of features missing from this code-base and IMHO it's not written in the prettiest way possible. It's also based on .Net 4.6.2 which means no support for .Net Core 2 or .Net Standard 2.
 
 We are using this package internally. Every time something doesn't work based on our new models and findings, I will jump in and add that missing feature. 
 
@@ -21,6 +21,7 @@ PRs are welcome.
 Converts [OData V4](http://docs.oasis-open.org/odata/odata/v4.0/odata-v4.0-part1-protocol.html) queries to [DocumentDB SQL](https://azure.microsoft.com/en-us/documentation/articles/documentdb-sql-query/) queries. 
 
 ## Release Notes
+* 2.0.31 Added support for using group as property name
 * 2.0.29 Added support for nested join condition based on child property
 * 2.0.28 Added support for single complex nodex - classes without id
 * 2.0.25 Added support for one nested join when part of a complex node
@@ -132,3 +133,4 @@ The options can be combined with bit operators such as ```(TranslateOptions.SELE
 
 * **Aboo Azarnoush** - Lambda Solutions
 * **Ziyou Zheng** - Microsoft Universal Store Team -
+* **Amir Hesami** - Palmerbet

--- a/azure-documentdb-odata-sql-samples/MockDataModel/MockOpenType.cs
+++ b/azure-documentdb-odata-sql-samples/MockDataModel/MockOpenType.cs
@@ -102,6 +102,7 @@ namespace azure_documentdb_odata_sql_tests
 		public const string LocationsPropertyName = "locations";
 		public const string CompetitorPropertyName = "competitor";
 		public const string CompetitorTwoPropertyName = "competitorTwo";
+		public const string GroupPropertyName = "group";
 
 		[DataMember(Name = IdPropertyName)]
 		[JsonProperty(PropertyName = IdPropertyName)]
@@ -123,6 +124,10 @@ namespace azure_documentdb_odata_sql_tests
 		[DataMember(Name = CompetitorTwoPropertyName)]
 		[JsonProperty(PropertyName = CompetitorTwoPropertyName)]
 		public Competitor Competitor2 { get; set; }
+
+		[DataMember(Name = GroupPropertyName)]
+		[JsonProperty(PropertyName = GroupPropertyName)]
+		public Group Group { get; set; }
 	}
 
 	[DataContract]
@@ -238,6 +243,16 @@ namespace azure_documentdb_odata_sql_tests
 
 	[DataContract]
 	public class Event
+	{
+		public const string IdPropertyName = "id";
+
+		[DataMember(Name = IdPropertyName)]
+		[JsonProperty(PropertyName = IdPropertyName)]
+		public string Id { get; set; }
+	}
+
+	[DataContract]
+	public class Group : Document
 	{
 		public const string IdPropertyName = "id";
 

--- a/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
+++ b/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
@@ -592,6 +592,84 @@ namespace azure_documentdb_odata_sql_tests
 		}
 
 		[TestMethod]
+		public void TranslateReservedKeyword_WhenClassHasReservedLowercaseGroupAsPropertyName()
+		{
+			// arrange
+			var oDataQueryOptions = GetODataQueryOptions("$filter=group/id eq 'groupId'");
+
+			// act
+			var sqlQuery = Translator.Translate(oDataQueryOptions, TranslateOptions.ALL);
+
+			// assert
+			Assert.AreEqual("SELECT * FROM c WHERE c['group'].id = 'groupId' ", sqlQuery);
+		}
+
+		[TestMethod]
+		public void TranslateReservedKeyword_WhenClassHasSecondLevelReservedLowercaseGroupAsPropertyName()
+		{
+			// arrange
+			var oDataQueryOptions = GetODataQueryOptions("$filter=product/group/id eq 'groupId'");
+
+			// act
+			var sqlQuery = Translator.Translate(oDataQueryOptions, TranslateOptions.ALL);
+
+			// assert
+			Assert.AreEqual("SELECT * FROM c WHERE c.product['group'].id = 'groupId' ", sqlQuery);
+		}
+
+		[TestMethod]
+		public void TranslateReservedKeyword_WhenClassHasReservedLowercaseGroupAsPropertyNameInJoin()
+		{
+			// arrange
+			var oDataQueryOptions = GetODataQueryOptions("$filter=competitors/any(d: d/group/id eq 'groupId')");
+
+			// act
+			var sqlQuery = Translator.Translate(oDataQueryOptions, TranslateOptions.ALL);
+
+			// assert
+			Assert.AreEqual("SELECT VALUE c FROM c JOIN d IN c.competitors WHERE d['group'].id = 'groupId' ", sqlQuery);
+		}
+
+		[TestMethod]
+		public void TranslateReservedKeyword_WhenClassHasReservedUppercaseGroupAsPropertyName()
+		{
+			// arrange
+			var oDataQueryOptions = GetODataQueryOptions("$filter=Group/id eq 'groupId'");
+
+			// act
+			var sqlQuery = Translator.Translate(oDataQueryOptions, TranslateOptions.ALL);
+
+			// assert
+			Assert.AreEqual("SELECT * FROM c WHERE c['Group'].id = 'groupId' ", sqlQuery);
+		}
+
+		[TestMethod]
+		public void TranslateReservedKeyword_WhenClassHasReservedMixedcaseGroupAsPropertyName()
+		{
+			// arrange
+			var oDataQueryOptions = GetODataQueryOptions("$filter=GrOup/id eq 'groupId'");
+
+			// act
+			var sqlQuery = Translator.Translate(oDataQueryOptions, TranslateOptions.ALL);
+
+			// assert
+			Assert.AreEqual("SELECT * FROM c WHERE c['GrOup'].id = 'groupId' ", sqlQuery);
+		}
+
+		[TestMethod]
+		public void TranslateReservedKeyword_WhenClassHasReservedGroupAsPropertyName()
+		{
+			// arrange
+			var oDataQueryOptions = GetODataQueryOptions("$filter=GrOup eq 'groupId'");
+
+			// act
+			var sqlQuery = Translator.Translate(oDataQueryOptions, TranslateOptions.ALL);
+
+			// assert
+			Assert.AreEqual("SELECT * FROM c WHERE c['GrOup'] = 'groupId' ", sqlQuery);
+		}
+
+		[TestMethod]
 		public void TranslateAnyToJoin_WhenThereIsOneNestedjoinAndConditionBasedOnChildProperty()
 		{
 			HttpRequestMessage.RequestUri = new Uri("http://localhost/User?$filter=payload/bet/legs/any(l:l/outcomes/any(o:o/competitor/id eq 'test'))");

--- a/azure-documentdb-odata-sql/Extensions/StringExtensions.cs
+++ b/azure-documentdb-odata-sql/Extensions/StringExtensions.cs
@@ -73,5 +73,28 @@ namespace Microsoft.Azure.Documents.OData.Sql.Extensions
 				return value;
 			return value.IndexOf(openParenthesis) == -1 && value[value.Length - 1] == closeParenthesis ? value.Substring(0, value.Length - 1) : value;
 		}
+		
+		public static string FindAndTranslateReservedKeywords(this string value)
+		{
+			var result = string.Copy(value);
+
+			var reservedKeywordsList = new List<string>
+			{
+				"group"
+			};
+
+			foreach (var reservedKeyword in reservedKeywordsList)
+			{
+				var reservedKeywordRegex = "(\\.)(" + reservedKeyword + ")(\\.| )";
+				var matches = Regex.Matches(result, reservedKeywordRegex, RegexOptions.IgnoreCase);
+				foreach (Match match in matches)
+				{
+					var newValue = $"[\'{match.Groups[2].Value}\']{match.Groups[3].Value}";
+					result = result.Replace(match.Value, newValue);
+				}
+			}
+
+			return result;
+		}
 	}
 }

--- a/azure-documentdb-odata-sql/ODataToSqlTranslator/ODataToSqlTranslator.cs
+++ b/azure-documentdb-odata-sql/ODataToSqlTranslator/ODataToSqlTranslator.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Azure.Documents.OData.Sql
 			_joinClauses = result.JoinClauses;
 
 			translation = translation.FindAndTranslateAny();
+			translation = translation.FindAndTranslateReservedKeywords();
 			return translation;
 		}
 


### PR DESCRIPTION
- Added FindAndTranslateReservedKeywords to string extensions to find an replace reserved keywords (for now group) to acceptable name.
- Updated ODataToSqlTranslator to call this extension method inTranslateFilterClause method.
- Added group class and property to MockData model.
- Added tests.