### PR TITLE
Fix regex for capturing property path in `any` function expression

### DIFF
--- a/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
+++ b/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
@@ -463,17 +463,17 @@ namespace azure_documentdb_odata_sql_tests
 			var sqlQuery = oDataToSqlTranslator.Translate(oDataQueryOptions, TranslateOptions.ALL & ~TranslateOptions.TOP_CLAUSE);
 			Assert.AreEqual("SELECT * FROM c WHERE ARRAY_CONTAINS(c.tags,'tag1') AND ARRAY_CONTAINS(c.tags,'tag2') AND ARRAY_CONTAINS(c.tags,'tag3') ", sqlQuery);
 		}
-
-        [TestMethod]
-        public void TranslateAny_WhenAnyIsNotTheFirstConditionInTheFilter()
-        {
-            HttpRequest.QueryString = QueryString.FromUriComponent(new Uri("http://localhost/User?$filter=parent/child eq 'childValue' and tags/any(t: t eq 'tag')"));
-            var oDataQueryOptions = new ODataQueryOptions(ODataQueryContext, HttpRequest);
-
-            var oDataToSqlTranslator = new ODataToSqlTranslator(new SQLQueryFormatter());
-            var sqlQuery = oDataToSqlTranslator.Translate(oDataQueryOptions, TranslateOptions.ALL & ~TranslateOptions.TOP_CLAUSE);
-            Assert.AreEqual("SELECT * FROM c WHERE c.parent.child = 'childValue' AND ARRAY_CONTAINS(c.tags,'tag') ", sqlQuery);
-        }
+		
+		[TestMethod]
+		public void TranslateAny_WhenAnyIsNotTheFirstConditionInTheFilter()
+		{
+			HttpRequest.QueryString = QueryString.FromUriComponent(new Uri("http://localhost/User?$filter=parent/child eq 'childValue' and tags/any(t: t eq 'tag')"));
+			var oDataQueryOptions = new ODataQueryOptions(ODataQueryContext, HttpRequest);
+			
+			var oDataToSqlTranslator = new ODataToSqlTranslator(new SQLQueryFormatter());
+			var sqlQuery = oDataToSqlTranslator.Translate(oDataQueryOptions, TranslateOptions.ALL & ~TranslateOptions.TOP_CLAUSE);
+			Assert.AreEqual("SELECT * FROM c WHERE c.parent.child = 'childValue' AND ARRAY_CONTAINS(c.tags,'tag') ", sqlQuery);
+		}
 
         [TestMethod]
 		public void TranslateAnyToJoin_WhenQueriedBasedOnChildProperty()

--- a/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
+++ b/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
@@ -464,7 +464,18 @@ namespace azure_documentdb_odata_sql_tests
 			Assert.AreEqual("SELECT * FROM c WHERE ARRAY_CONTAINS(c.tags,'tag1') AND ARRAY_CONTAINS(c.tags,'tag2') AND ARRAY_CONTAINS(c.tags,'tag3') ", sqlQuery);
 		}
 
-		[TestMethod]
+        [TestMethod]
+        public void TranslateAny_WhenAnyIsNotTheFirstConditionInTheFilter()
+        {
+            HttpRequest.QueryString = QueryString.FromUriComponent(new Uri("http://localhost/User?$filter=parent/child eq 'childValue' and tags/any(t: t eq 'tag')"));
+            var oDataQueryOptions = new ODataQueryOptions(ODataQueryContext, HttpRequest);
+
+            var oDataToSqlTranslator = new ODataToSqlTranslator(new SQLQueryFormatter());
+            var sqlQuery = oDataToSqlTranslator.Translate(oDataQueryOptions, TranslateOptions.ALL & ~TranslateOptions.TOP_CLAUSE);
+            Assert.AreEqual("SELECT * FROM c WHERE c.parent.child = 'childValue' AND ARRAY_CONTAINS(c.tags,'tag') ", sqlQuery);
+        }
+
+        [TestMethod]
 		public void TranslateAnyToJoin_WhenQueriedBasedOnChildProperty()
 		{
 			HttpRequest.QueryString = QueryString.FromUriComponent(new Uri("http://localhost/User?$filter=products/any(p: p/name eq 'test')"));

--- a/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
+++ b/azure-documentdb-odata-sql-samples/ODataToSqlSamples.cs
@@ -463,7 +463,7 @@ namespace azure_documentdb_odata_sql_tests
 			var sqlQuery = oDataToSqlTranslator.Translate(oDataQueryOptions, TranslateOptions.ALL & ~TranslateOptions.TOP_CLAUSE);
 			Assert.AreEqual("SELECT * FROM c WHERE ARRAY_CONTAINS(c.tags,'tag1') AND ARRAY_CONTAINS(c.tags,'tag2') AND ARRAY_CONTAINS(c.tags,'tag3') ", sqlQuery);
 		}
-		
+
 		[TestMethod]
 		public void TranslateAny_WhenAnyIsNotTheFirstConditionInTheFilter()
 		{
@@ -474,8 +474,8 @@ namespace azure_documentdb_odata_sql_tests
 			var sqlQuery = oDataToSqlTranslator.Translate(oDataQueryOptions, TranslateOptions.ALL & ~TranslateOptions.TOP_CLAUSE);
 			Assert.AreEqual("SELECT * FROM c WHERE c.parent.child = 'childValue' AND ARRAY_CONTAINS(c.tags,'tag') ", sqlQuery);
 		}
-
-        [TestMethod]
+		
+		[TestMethod]
 		public void TranslateAnyToJoin_WhenQueriedBasedOnChildProperty()
 		{
 			HttpRequest.QueryString = QueryString.FromUriComponent(new Uri("http://localhost/User?$filter=products/any(p: p/name eq 'test')"));

--- a/azure-documentdb-odata-sql/Extensions/StringExtensions.cs
+++ b/azure-documentdb-odata-sql/Extensions/StringExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Documents.OData.Sql.Extensions
 	{
 		public static string FindAndTranslateAny(this string translation)
 		{
-			const string anyRegEx = @"(c\.[^\/]*)\/any\([^:]*:[^=]*= ([^)]*)\)";
+			const string anyRegEx = @"(c\.[\w\.\/]+)\/any\([^:]*:[^=]*= ([^)]*)\)";
 			const string arrayContainsFormat = "ARRAY_CONTAINS({0},{1})";
 			var finalTranslation = translation;
 

--- a/azure-documentdb-odata-sql/Extensions/StringExtensions.cs
+++ b/azure-documentdb-odata-sql/Extensions/StringExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Documents.OData.Sql.Extensions
 	{
 		public static string FindAndTranslateAny(this string translation)
 		{
-			const string anyRegEx = @"(c\.[\w\.\/]+)\/any\([^:]*:[^=]*= ([^)]*)\)";
+			const string anyRegEx = @"(c\.[\w\.]+)\/any\([^:]*:[^=]*= ([^)]*)\)";
 			const string arrayContainsFormat = "ARRAY_CONTAINS({0},{1})";
 			var finalTranslation = translation;
 


### PR DESCRIPTION
- **Issue**: The original regex incorrectly captured the entire expression before `/any`, including comparison operators and unrelated parts of the query, when property paths appeared after conditional statements.
  
  **Example**:
  - Input: `c.parent.child eq 'childValue' and c.tags/any(t: t eq 'tag')`
  - Expected group 1: `c.tags`, but it incorrectly captured `c.parent.child eq 'childValue' and c.tags`.

- **Solution**:
  - Updated the regex to limit the property path capture (`c\.[\w\.]+`) to alphanumeric characters, underscores, and dots, ensuring it stops before slashes (`/`).
  - This resolves the issue where the regex captured more than intended, especially when property paths appear before the '\any` expression.

- **Testing**:
  - Verified the regex on multiple query formats to ensure it correctly captures the intended groups.
  - Examples that were tested:
    - `c.parent.child eq 'childValue' and c.tags/any(t: t eq 'tag')`
    - `c.tags/any(t: t eq 'tag') and c.parent.child eq 'childValue'`

This PR ensures that the regex now accurately handles the capture of property paths in `any` function expressions.